### PR TITLE
Add a new callback for subscriptions

### DIFF
--- a/org.eclipse.paho.client.mqttv3/pom.xml
+++ b/org.eclipse.paho.client.mqttv3/pom.xml
@@ -145,6 +145,6 @@
             </plugins>
         </pluginManagement>
     </build>
-    <version>1.2.7.timer-ping-sender</version>
+    <version>1.3.0</version>
 </project>
 

--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttActionListener.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/IMqttActionListener.java
@@ -1,5 +1,7 @@
 package org.eclipse.paho.client.mqttv3;
 
+import java.util.List;
+
 /**
  * Implementors of this interface will be notified when an asynchronous action completes.
  * 
@@ -27,4 +29,12 @@ public interface IMqttActionListener {
 	 * @param exception thrown by the action that has failed
 	 */
     void onFailure(IMqttToken asyncActionToken, Throwable exception);
+
+	/**
+	 * This method is invoked for subscribe actions.
+	 * @param asyncActionToken associated with the action
+	 * @param successTopics - The topics which are successfully subscribed
+	 * @param failedTopics - The topics for which subscription has failed
+	 */
+	default void onSubscribeResult(IMqttToken asyncActionToken, List<String> successTopics, List<String> failedTopics) {}
 }


### PR DESCRIPTION
Add new callback for subscribe action which provides the following:
* List of topics which are successfully subscribed
* List of topics which failed
